### PR TITLE
Introducing derridaean_similarity

### DIFF
--- a/hyperdb/galaxy_brain_math_shit.py
+++ b/hyperdb/galaxy_brain_math_shit.py
@@ -30,15 +30,6 @@ def derridaean_similarity(vectors, query_vector):
 
 def hyper_SVM_ranking_algorithm_sort(vectors, query_vector, top_k=5, metric=cosine_similarity):
     """HyperSVMRanking (Such Vector, Much Ranking) algorithm proposed by Andrej Karpathy (2023) https://arxiv.org/abs/2303.18231"""
-    metrics = {
-        'cosine_similarity': cosine_similarity,
-        'euclidean_metric': euclidean_metric,
-        'derridaean_similarity': derridaean_similarity
-    }
-    
-    if metric not in metrics:
-        raise ValueError(f"Invalid metric '{metric}'. Available options are: {', '.join(metrics.keys())}")
-
-    similarities = metrics[metric](vectors, query_vector)
+    similarities = metric(vectors, query_vector)
     top_indices = np.argsort(similarities, axis=0)[-top_k:][::-1]
     return top_indices.flatten()

--- a/hyperdb/galaxy_brain_math_shit.py
+++ b/hyperdb/galaxy_brain_math_shit.py
@@ -1,5 +1,6 @@
 """Super valuable proprietary algorithm for ranking vector similarity. Top secret."""
 import numpy as np
+import random
 
 def get_norm_vector(vector):
     if len(vector.shape) == 1:
@@ -13,16 +14,31 @@ def cosine_similarity(vectors, query_vector):
     similarities = np.dot(norm_vectors, norm_query_vector.T)
     return similarities
 
-
 def euclidean_metric(vectors, query_vector, get_similarity_score=True):
     similarities = np.linalg.norm(vectors - query_vector, axis=1)
     if get_similarity_score:
         similarities = 1 / (1 + similarities)
     return similarities
 
+def derridaean_similarity(vectors, query_vector):
+    def random_change(value):
+        return value + random.uniform(-0.2, 0.2)
+
+    similarities = cosine_similarity(vectors, query_vector)
+    derrida_similarities = np.vectorize(random_change)(similarities)
+    return derrida_similarities
 
 def hyper_SVM_ranking_algorithm_sort(vectors, query_vector, top_k=5, metric=cosine_similarity):
     """HyperSVMRanking (Such Vector, Much Ranking) algorithm proposed by Andrej Karpathy (2023) https://arxiv.org/abs/2303.18231"""
-    similarities = metric(vectors, query_vector)
+    metrics = {
+        'cosine_similarity': cosine_similarity,
+        'euclidean_metric': euclidean_metric,
+        'derridaean_similarity': derridaean_similarity
+    }
+    
+    if metric not in metrics:
+        raise ValueError(f"Invalid metric '{metric}'. Available options are: {', '.join(metrics.keys())}")
+
+    similarities = metrics[metric](vectors, query_vector)
     top_indices = np.argsort(similarities, axis=0)[-top_k:][::-1]
     return top_indices.flatten()

--- a/hyperdb/hyperdb.py
+++ b/hyperdb/hyperdb.py
@@ -38,7 +38,7 @@ class HyperDB:
         elif similarity_metric.__contains__("derrida"):
             self.similarity_metric = derridaean_similarity
         else:
-            raise Exception("Similarity metric not supported. Please use either 'cosine', 'euclidean' or 'derridean'.")
+            raise Exception("Similarity metric not supported. Please use either 'cosine', 'euclidean' or 'derrida'.")
 
     def add_document(self, document, vector=None):
         if vector is None:

--- a/hyperdb/hyperdb.py
+++ b/hyperdb/hyperdb.py
@@ -1,7 +1,7 @@
 import json
 import numpy as np
 import openai
-from hyperdb.galaxy_brain_math_shit import cosine_similarity, euclidean_metric, hyper_SVM_ranking_algorithm_sort
+from hyperdb.galaxy_brain_math_shit import cosine_similarity, euclidean_metric, derridaean_similarity, hyper_SVM_ranking_algorithm_sort
 
 def get_embedding(documents, key=None, model="text-embedding-ada-002"):
     """Default embedding function that uses OpenAI Embeddings."""
@@ -35,8 +35,10 @@ class HyperDB:
             self.similarity_metric = cosine_similarity
         elif similarity_metric.__contains__("euclidean"):
             self.similarity_metric = euclidean_metric
+        elif similarity_metric.__contains__("derrida"):
+            self.similarity_metric = derridaean_similarity
         else:
-            raise Exception("Similarity metric not supported. Please use either 'cosine' or 'euclidean'.")
+            raise Exception("Similarity metric not supported. Please use either 'cosine', 'euclidean' or 'derridean'.")
 
     def add_document(self, document, vector=None):
         if vector is None:


### PR DESCRIPTION
In this merge request, I propose the addition of a new similarity measure, "derridaean_similarity," which is inspired by Derrida's notion of différance and his criticism of the transcendental signified. derridaean_similarity emphasizes the fluidity and ever-changing nature of meaning, as opposed to conventional measures like cosine and Euclidean distance, which assume that meaning can be fixed and quantified in vector spaces.

The Derrida_similarity function generates similarity scores based on cosine similarity but introduces a random change to the scores with each call, reflecting the dynamic nature of meaning in line with Derrida's philosophy.

This merge request includes the implementation of the derridaean_similarity function and its integration into the hyper_SVM_ranking_algorithm_sort function as an optional metric. This addition will boost performance and deliver a death blow to logocentrism in ML.

Please review the changes and let me know if you have any feedback or suggestions. Thank you!