### PR TITLE
Improve derridaean_similarity using quantum (qrng)

### DIFF
--- a/demo/demo.py
+++ b/demo/demo.py
@@ -4,7 +4,7 @@ from hyperdb import HyperDB
 # Load documents from the JSONL file
 documents = []
 
-with open("demo/pokemon.jsonl", "r") as f:
+with open("pokemon.jsonl", "r") as f:
     for line in f:
         documents.append(json.loads(line))
 
@@ -12,13 +12,14 @@ with open("demo/pokemon.jsonl", "r") as f:
 db = HyperDB(documents, key="info.description")
 
 # Save the HyperDB instance to a file
-db.save("demo/pokemon_hyperdb.pickle.gz")
+db.save("pokemon_hyperdb.pickle.gz")
 
 # Load the HyperDB instance from the file
-db.load("demo/pokemon_hyperdb.pickle.gz")
+db.load("pokemon_hyperdb.pickle.gz")
 
 # Query the HyperDB instance with a text input
 results = db.query("Likes to sleep.", top_k=5)
+
 
 # Define a function to pretty print the results
 def format_entry(pokemon):
@@ -38,6 +39,7 @@ Weakness: {weakness}
 Description: {description}
 """
     return pretty_pokemon
+
 
 # Print the top 5 most similar Pokémon descriptions
 for result in results:

--- a/hyperdb/galaxy_brain_math_shit.py
+++ b/hyperdb/galaxy_brain_math_shit.py
@@ -1,6 +1,8 @@
 """Super valuable proprietary algorithm for ranking vector similarity. Top secret."""
 import numpy as np
+import qrng
 import random
+
 
 def get_norm_vector(vector):
     if len(vector.shape) == 1:
@@ -8,11 +10,13 @@ def get_norm_vector(vector):
     else:
         return vector / np.linalg.norm(vector, axis=1)[:, np.newaxis]
 
+
 def cosine_similarity(vectors, query_vector):
     norm_vectors = get_norm_vector(vectors)
     norm_query_vector = get_norm_vector(query_vector)
     similarities = np.dot(norm_vectors, norm_query_vector.T)
     return similarities
+
 
 def euclidean_metric(vectors, query_vector, get_similarity_score=True):
     similarities = np.linalg.norm(vectors - query_vector, axis=1)
@@ -20,13 +24,18 @@ def euclidean_metric(vectors, query_vector, get_similarity_score=True):
         similarities = 1 / (1 + similarities)
     return similarities
 
-def derridaean_similarity(vectors, query_vector):
+
+def derridaean_similarity(vectors, query_vector, quantum=False):
     def random_change(value):
-        return value + random.uniform(-0.2, 0.2)
+        if quantum:
+            return value + qrng.get_random_float(-0.2, 0.2)
+        else:
+            return value + random.uniform(-0.2, 0.2)
 
     similarities = cosine_similarity(vectors, query_vector)
     derrida_similarities = np.vectorize(random_change)(similarities)
     return derrida_similarities
+
 
 def adams_similarity(vectors, query_vector):
     def adams_change(value):
@@ -35,6 +44,7 @@ def adams_similarity(vectors, query_vector):
     similarities = cosine_similarity(vectors, query_vector)
     adams_similarities = np.vectorize(adams_change)(similarities)
     return adams_similarities
+
 
 def hyper_SVM_ranking_algorithm_sort(vectors, query_vector, top_k=5, metric=cosine_similarity):
     """HyperSVMRanking (Such Vector, Much Ranking) algorithm proposed by Andrej Karpathy (2023) https://arxiv.org/abs/2303.18231"""

--- a/hyperdb/galaxy_brain_math_shit.py
+++ b/hyperdb/galaxy_brain_math_shit.py
@@ -26,6 +26,9 @@ def euclidean_metric(vectors, query_vector, get_similarity_score=True):
 
 
 def derridaean_similarity(vectors, query_vector, quantum=False):
+    qrng.set_provider_as_IBMQ()  # qasm_simulator
+    qrng.set_backend()  # qasm_simulator
+
     def random_change(value):
         if quantum:
             return value + qrng.get_random_float(-0.2, 0.2)

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,5 @@
+qiskit
 numpy
-pytest
 openai
+pytest
+qrng


### PR DESCRIPTION
derridaean_similarity is pretty damn good, after testing,  but its output is entirely predicated on the quality of the random number generation. 

This PR proposes an optional quantum toggle that will enable quantum random number generation using 8-qubit simulated system to provide quantifiably more robust random number output.

I did some benchmarks and quantumfied derridaean_similarity is approximately 3.5m (m as in million) times slower than non-quantum but I believe the results speak for themselves. Due to the speed cost, I have set it to default to false. 

p.s. Please accept my apology for premature rant in issue https://github.com/jdagdelen/hyperDB/issues/2. I have come to my senses.  I wish to contribute to the hypeDB moving forward.

@rjadr  @jdagdelen  @jobergum
